### PR TITLE
Read file from secondary buckets, when it doesn't exist in primary

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ end
 :bucket_name
 :access_key_id
 :secret_access_key
-:region               # default 'us-east-1', see Dragonfly::S3DataStore::REGIONS for options
-:storage_headers      # defaults to {'x-amz-acl' => 'public-read'}, can be overridden per-write - see below
-:url_scheme           # defaults to "http"
-:url_host             # defaults to "<bucket-name>.s3.amazonaws.com", or "s3.amazonaws.com/<bucket-name>" if not a valid subdomain
-:use_iam_profile      # boolean - if true, no need for access_key_id or secret_access_key
-:root_path            # store all content under a subdirectory - uids will be relative to this - defaults to nil
-:fog_storage_options  # hash for passing any extra options to Fog::Storage.new, e.g. {path_style: true}
+:region                  # default 'us-east-1', see Dragonfly::S3DataStore::REGIONS for options
+:storage_headers         # defaults to {'x-amz-acl' => 'public-read'}, can be overridden per-write - see below
+:url_scheme              # defaults to "http"
+:url_host                # defaults to "<bucket-name>.s3.amazonaws.com", or "s3.amazonaws.com/<bucket-name>" if not a valid subdomain
+:use_iam_profile         # boolean - if true, no need for access_key_id or secret_access_key
+:root_path               # store all content under a subdirectory - uids will be relative to this - defaults to nil
+:fog_storage_options     # hash for passing any extra options to Fog::Storage.new, e.g. {path_style: true}
+:secondary_bucket_names  # you can provide an array of secondary buckets to search for a file – useful for staging or development server to avoid copying production bucket
 ```
 
 ### Per-storage options

--- a/spec/s3_data_store_spec.rb
+++ b/spec/s3_data_store_spec.rb
@@ -212,6 +212,33 @@ describe Dragonfly::S3DataStore do
     end
   end
 
+  describe "with secondary buckets" do
+    let(:bucket_name) { "staging-bucket" }
+    let(:secondary_bucket_names) { ["production-bucket", "backup-bucket"] }
+    let(:uid) { "photo.jpg" }
+    let(:data_store) do
+      Fog.mock!
+      Dragonfly::S3DataStore.new(
+        :bucket_name => bucket_name,
+        :secondary_bucket_names => secondary_bucket_names,
+        :access_key_id => 'XXXXXXXXX',
+        :secret_access_key => 'XXXXXXXXX',
+        :region => 'eu-west-1'
+      )
+    end
+
+    before do
+      data_store.storage.put_bucket(secondary_bucket_names[1])
+      data_store.storage.put_object(secondary_bucket_names[1], uid, "something")
+    end
+
+    it "finds file in the provided secondary buckets, when it doesn't exist in primary bucket" do
+      response = data_store.read(uid)
+      response.should be_kind_of(Array)
+      response[0].should eql("something")
+    end
+  end
+
   describe "autocreating the bucket" do
     it "should create the bucket on write if it doesn't exist" do
       @data_store.bucket_name = "dragonfly-test-blah-blah-#{rand(100000000)}"


### PR DESCRIPTION
With this pull request, user can specify a list of buckets that will be used as a fallback, when requested file can't be found in the primary bucket. This is useful when you don't want to copy your whole production bucket to staging every time you decide to run staging from a copy of production database. In this case, on the staging server, you set production bucket as a secondary bucket. Writes will only go to the primary bucket, which, in this case, is staging.