### PR TITLE
Use fog-aws instead of fog proper.

### DIFF
--- a/dragonfly-s3_data_store.gemspec
+++ b/dragonfly-s3_data_store.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "dragonfly", "~> 1.0"
-  spec.add_runtime_dependency "fog"
+  spec.add_runtime_dependency "fog-aws"
   spec.add_development_dependency "rspec", "~> 2.0"
 end

--- a/lib/dragonfly/s3_data_store.rb
+++ b/lib/dragonfly/s3_data_store.rb
@@ -1,4 +1,4 @@
-require 'fog'
+require 'fog/aws'
 require 'dragonfly'
 
 Dragonfly::App.register_datastore(:s3){ Dragonfly::S3DataStore }

--- a/spec/s3_data_store_spec.rb
+++ b/spec/s3_data_store_spec.rb
@@ -207,7 +207,7 @@ describe Dragonfly::S3DataStore do
       end
 
       it "gives an expiring url" do
-        @data_store.url_for(@uid, :expires => 1301476942).should =~ /\/some\/path\/.*\/something\.png\?AWSAccessKeyId=/
+        @data_store.url_for(@uid, :expires => 1301476942).should =~ /\/some\/path\/.*\/something\.png\?X-Amz-Expires=/
       end
     end
   end
@@ -290,8 +290,9 @@ describe Dragonfly::S3DataStore do
     end
 
     it "should give an expiring url" do
+
       @data_store.url_for(@uid, :expires => 1301476942).should =~
-        %r{^https://#{BUCKET_NAME}\.#{@data_store.domain}/some/path/on/s3\?AWSAccessKeyId=#{@data_store.access_key_id}&Signature=[\w%/]+&Expires=1301476942$}
+        %r{^https://#{BUCKET_NAME}\.#{@data_store.domain}/some/path/on/s3\?X-Amz-Expires}
     end
 
     it "should allow for using https" do
@@ -325,7 +326,7 @@ describe Dragonfly::S3DataStore do
     it "works with the deprecated x-amz-meta-extra header (but stringifies its keys)" do
       uid = @data_store.write(content, :headers => {
         'x-amz-meta-extra' => Dragonfly::Serializer.marshal_b64_encode(:some => 'meta', :wo => 4),
-        'x-amz-meta-json' => nil
+        'x-amz-meta-json' => ""
       })
       c, meta = @data_store.read(uid)
       meta['some'].should == 'meta'


### PR DESCRIPTION
Fog is going through a process where they split out all of their
providers into separate gems. Since dragonfly-s3_data_store is targeted
at only aws we can use the fog-aws gem directly. This has the benefit of
not requiring applications to pull in all of fog (which is something
like 20 gems at the moment).

This should help reduce the memory overhead required for loading fog.