### PR TITLE
Add eu-central-1 (Frankfurt) to supported regions

### DIFF
--- a/lib/dragonfly/s3_data_store.rb
+++ b/lib/dragonfly/s3_data_store.rb
@@ -17,6 +17,7 @@ module Dragonfly
       'ap-southeast-1' => 's3-ap-southeast-1.amazonaws.com',
       'ap-southeast-2' => 's3-ap-southeast-2.amazonaws.com',
       'eu-west-1' => 's3-eu-west-1.amazonaws.com',
+      'eu-central-1' => 's3-eu-central-1.amazonaws.com',
       'sa-east-1' => 's3-sa-east-1.amazonaws.com'
     }
 


### PR DESCRIPTION
Amazon opened a new datacenter in Frankfurt, Germany last year. I've added it to the list of supported regions.