### PR TITLE
Allow non ascii as filename

### DIFF
--- a/lib/dragonfly/s3_data_store.rb
+++ b/lib/dragonfly/s3_data_store.rb
@@ -136,7 +136,7 @@ module Dragonfly
     end
 
     def generate_uid(name)
-      "#{Time.now.strftime '%Y/%m/%d/%H/%M/%S'}/#{rand(1000)}/#{name.gsub(/[^\w.]+/, '_')}"
+      "#{Time.now.strftime '%Y/%m/%d/%H/%M/%S'}/#{rand(1000)}/#{name}"
     end
 
     def full_path(uid)

--- a/spec/s3_data_store_spec.rb
+++ b/spec/s3_data_store_spec.rb
@@ -331,6 +331,13 @@ describe Dragonfly::S3DataStore do
       meta['some'].should == 'meta'
       meta['wo'].should == 4
     end
+
+    it "works with non ascii character" do
+      content = Dragonfly::Content.new(app, "hi", "name" => "こんにちは.txt")
+      uid = @data_store.write(content)
+      c, meta = @data_store.read(uid)
+      meta['name'].should == 'こんにちは.txt'
+    end
   end
 
   describe "fog_storage_options" do

--- a/spec/s3_data_store_spec.rb
+++ b/spec/s3_data_store_spec.rb
@@ -75,7 +75,7 @@ describe Dragonfly::S3DataStore do
     it "should work ok with files with funny names" do
       content.name = "A Picture with many spaces in its name (at 20:00 pm).png"
       uid = @data_store.write(content)
-      uid.should =~ /A_Picture_with_many_spaces_in_its_name_at_20_00_pm_\.png$/
+      uid.should =~ /A Picture with many spaces in its name \(at 20:00 pm\)\.png/
       new_content.update(*@data_store.read(uid))
       new_content.data.should == 'eggheads'
     end


### PR DESCRIPTION
When filename contains non ascii character, it fails to upload due to [validation of fog-aws](https://github.com/fog/fog-aws/blob/v0.1.2/lib/fog/aws/requests/storage/put_object.rb#L33).
This PR will fix https://github.com/markevans/dragonfly/issues/389.