### PR TITLE
Add a CHANGELOG file with 1.2 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# v1.2
+
+* Save files into a different directory structure, e.g. '2015/08/03/5bccfdd8-0de2-4efc-b3f3-f4e96bcc4afa/file.png' rather than '2015/08/03/12/03/24/492/file.png'. This does not affect any functionality and won't break any of your old content! It's just more robust. (df7453a0)


### PR DESCRIPTION
I was recently updating this gem and the lack of a CHANGELOG threw me a bit, so I've pulled the note in the README into its own CHANGELOG section for the 1.2 release.
