### PR TITLE
Honor native content type from s3 based storage

### DIFF
--- a/lib/dragonfly/s3_data_store.rb
+++ b/lib/dragonfly/s3_data_store.rb
@@ -136,12 +136,15 @@ module Dragonfly
     end
 
     def headers_to_meta(headers)
+      meta = {}
+      meta['mime_type'] = headers['Content-Type'] if headers.key?('Content-Type')
       json = headers['x-amz-meta-json']
       if json && !json.empty?
-        unescape_meta_values(Serializer.json_decode(json))
+        meta.merge(unescape_meta_values(Serializer.json_decode(json)))
       elsif marshal_data = headers['x-amz-meta-extra']
-        Utils.stringify_keys(Serializer.marshal_b64_decode(marshal_data))
+        meta.merge(Utils.stringify_keys(Serializer.marshal_b64_decode(marshal_data)))
       end
+      meta
     end
 
     def meta_to_headers(meta)

--- a/lib/dragonfly/s3_data_store.rb
+++ b/lib/dragonfly/s3_data_store.rb
@@ -137,13 +137,13 @@ module Dragonfly
 
     def headers_to_meta(headers)
       meta = {}
-      meta['mime_type'] = headers['Content-Type'] if headers.key?('Content-Type')
       json = headers['x-amz-meta-json']
       if json && !json.empty?
         meta.merge(unescape_meta_values(Serializer.json_decode(json)))
       elsif marshal_data = headers['x-amz-meta-extra']
         meta.merge(Utils.stringify_keys(Serializer.marshal_b64_decode(marshal_data)))
       end
+      meta['mime_type'] ||= headers['Content-Type'] if headers.key?('Content-Type')
       meta
     end
 


### PR DESCRIPTION
When the file was not originally uploaded by dragonfly and does not have the x-amz-meta-extra header with the name out of which the extension and mime type can be derived, this pull request provides a fall back method to inherit it

It reduces the case where the file is served as application/octet-stream as the fall back default.