### PR TITLE
add option to disable sync_clock calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ end
 :use_iam_profile      # boolean - if true, no need for access_key_id or secret_access_key
 :root_path            # store all content under a subdirectory - uids will be relative to this - defaults to nil
 :fog_storage_options  # hash for passing any extra options to Fog::Storage.new, e.g. {path_style: true}
+:sync_clock           # boolean - defaults to true, will call fog storage.sync_clock on storage initialization
 ```
 
 ### Per-storage options

--- a/lib/dragonfly/s3_data_store.rb
+++ b/lib/dragonfly/s3_data_store.rb
@@ -24,9 +24,10 @@ module Dragonfly
       @use_iam_profile = opts[:use_iam_profile]
       @root_path = opts[:root_path]
       @fog_storage_options = opts[:fog_storage_options] || {}
+      @sync_clock = opts.fetch(:sync_clock, true)
     end
 
-    attr_accessor :bucket_name, :access_key_id, :secret_access_key, :region, :storage_headers, :url_scheme, :url_host, :use_iam_profile, :root_path, :fog_storage_options
+    attr_accessor :bucket_name, :access_key_id, :secret_access_key, :region, :storage_headers, :url_scheme, :url_host, :use_iam_profile, :root_path, :fog_storage_options, :sync_clock
 
     def write(content, opts={})
       ensure_configured
@@ -89,7 +90,7 @@ module Dragonfly
           :region => region,
           :use_iam_profile => use_iam_profile
         }).reject {|name, option| option.nil?})
-        storage.sync_clock
+        storage.sync_clock if sync_clock
         storage
       end
     end

--- a/spec/s3_data_store_spec.rb
+++ b/spec/s3_data_store_spec.rb
@@ -345,4 +345,35 @@ describe Dragonfly::S3DataStore do
       ))
     end
   end
+
+  describe "sync_clock_option" do
+    it "adds default sync_clock option of true" do
+      storage = double("Fog::Storage")
+      expect(Fog::Storage).to receive(:new).and_return(storage)
+      storage.should_receive(:sync_clock).at_least(:once)
+
+      data_store = Dragonfly::S3DataStore.new(
+        :bucket_name => BUCKET_NAME,
+        :access_key_id => 'XXXXXXXXX',
+        :secret_access_key => 'XXXXXXXXX',
+        :region => 'eu-west-1'
+      )
+      data_store.storage
+    end
+
+    it "accepts sync_clock option" do
+      storage = double("Fog::Storage")
+      expect(Fog::Storage).to receive(:new).and_return(storage)
+      storage.should_not_receive(:sync_clock)
+
+      data_store = Dragonfly::S3DataStore.new(
+        :bucket_name => BUCKET_NAME,
+        :access_key_id => 'XXXXXXXXX',
+        :secret_access_key => 'XXXXXXXXX',
+        :region => 'eu-west-1',
+        :sync_clock => false
+      )
+      data_store.storage
+    end
+  end
 end


### PR DESCRIPTION
Add option to disable sync_clock calls:

1. The sync_clock method calls get_service which does a ListBuckets operation. If the IAM user does not have permissions to ListBuckets (as I assume would be common when granting bucket specific permissions to the credentials used for fog) it generates a ton of http 403's with AccessDenied (which can get logged in AWS Cloudtrail).
2. This is unnecessary overhead if the server's clocks are already synchronized 

